### PR TITLE
fix(awsim_labs_sensor_kit_launch): add autoware prefix to vehicle_velocity_converter

### DIFF
--- a/awsim_labs_sensor_kit_launch/launch/sensing.launch.xml
+++ b/awsim_labs_sensor_kit_launch/launch/sensing.launch.xml
@@ -23,7 +23,7 @@
     <!-- GNSS Drives in not needed because the AWSIM already publishes both gnss pose and pose with covariance topics -->
 
     <!-- Vehicle Velocity Converter  -->
-    <include file="$(find-pkg-share vehicle_velocity_converter)/launch/vehicle_velocity_converter.launch.xml">
+    <include file="$(find-pkg-share autoware_vehicle_velocity_converter)/launch/vehicle_velocity_converter.launch.xml">
       <arg name="input_vehicle_velocity_topic" value="/vehicle/status/velocity_status"/>
       <arg name="output_twist_with_covariance" value="/sensing/vehicle_velocity_converter/twist_with_covariance"/>
     </include>

--- a/awsim_labs_sensor_kit_launch/package.xml
+++ b/awsim_labs_sensor_kit_launch/package.xml
@@ -11,6 +11,7 @@
 
   <exec_depend>autoware_gnss_poser</exec_depend>
   <exec_depend>autoware_pointcloud_preprocessor</exec_depend>
+  <exec_depend>autoware_vehicle_velocity_converter</exec_depend>
   <exec_depend>common_sensor_launch</exec_depend>
   <exec_depend>tamagawa_imu_driver</exec_depend>
   <exec_depend>topic_tools</exec_depend>


### PR DESCRIPTION
## Description
This PR will add the autoware prefix to `vehicle_velocity_converter` due to the changes in https://github.com/autowarefoundation/autoware.universe/pull/8967 .

This should merge with https://github.com/autowarefoundation/autoware.universe/pull/8967

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
