### PR TITLE
chore: bump version to 0.39.0

### DIFF
--- a/awsim_labs_sensor_kit_description/CHANGELOG.rst
+++ b/awsim_labs_sensor_kit_description/CHANGELOG.rst
@@ -1,0 +1,8 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package awsim_labs_sensor_kit_description
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.39.0 (2024-12-12)
+-------------------
+* refactor: update for the awsim_labs (`#2 <https://github.com/autowarefoundation/awsim_labs_sensor_kit_launch/issues/2>`_)
+* Contributors: M. Fatih Cırıt

--- a/awsim_labs_sensor_kit_description/package.xml
+++ b/awsim_labs_sensor_kit_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>awsim_labs_sensor_kit_description</name>
-  <version>0.1.0</version>
+  <version>0.39.0</version>
   <description>The awsim_labs_sensor_kit_description package</description>
   <maintainer email="piotr.jaroszek@robotec.ai">Piotr Jaroszek</maintainer>
   <license>Apache License 2.0</license>

--- a/awsim_labs_sensor_kit_launch/CHANGELOG.rst
+++ b/awsim_labs_sensor_kit_launch/CHANGELOG.rst
@@ -1,0 +1,12 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package awsim_labs_sensor_kit_launch
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.39.0 (2024-12-12)
+-------------------
+* feat: ring outlier filter and distortion correction node load from param file (`#6 <https://github.com/autowarefoundation/awsim_labs_sensor_kit_launch/issues/6>`_)
+* chore(package_xml): added autoware\_ prefix to gnss_poser (`#4 <https://github.com/autowarefoundation/awsim_labs_sensor_kit_launch/issues/4>`_)
+* refactor: renamed the package name imu_corrector to autoware_imu_corrector (`#5 <https://github.com/autowarefoundation/awsim_labs_sensor_kit_launch/issues/5>`_)
+* refactor!: pointcloud_preprocessor prefix package and namespace with autoware (`#3 <https://github.com/autowarefoundation/awsim_labs_sensor_kit_launch/issues/3>`_)
+* refactor: update for the awsim_labs (`#2 <https://github.com/autowarefoundation/awsim_labs_sensor_kit_launch/issues/2>`_)
+* Contributors: A. Sena Yılmaz, Amadeusz Szymko, Kenzo Lobos Tsunekawa, M. Fatih Cırıt, TaikiYamada4

--- a/awsim_labs_sensor_kit_launch/package.xml
+++ b/awsim_labs_sensor_kit_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>awsim_labs_sensor_kit_launch</name>
-  <version>0.1.0</version>
+  <version>0.39.0</version>
   <description>The awsim_labs_sensor_kit_launch package</description>
   <maintainer email="piotr.jaroszek@robotec.ai">Piotr Jaroszek</maintainer>
   <license>Apache License 2.0</license>

--- a/common_awsim_labs_sensor_launch/CHANGELOG.rst
+++ b/common_awsim_labs_sensor_launch/CHANGELOG.rst
@@ -1,0 +1,11 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package common_awsim_labs_sensor_launch
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.39.0 (2024-12-12)
+-------------------
+* feat(common_awsim_labs_sensor_launch): distortion corrector add new param (`#7 <https://github.com/autowarefoundation/awsim_labs_sensor_kit_launch/issues/7>`_)
+* feat: ring outlier filter and distortion correction node load from param file (`#6 <https://github.com/autowarefoundation/awsim_labs_sensor_kit_launch/issues/6>`_)
+* refactor!: pointcloud_preprocessor prefix package and namespace with autoware (`#3 <https://github.com/autowarefoundation/awsim_labs_sensor_kit_launch/issues/3>`_)
+* refactor: update for the awsim_labs (`#2 <https://github.com/autowarefoundation/awsim_labs_sensor_kit_launch/issues/2>`_)
+* Contributors: A. Sena Yılmaz, Amadeusz Szymko, M. Fatih Cırıt, Yi-Hsiang Fang (Vivid)

--- a/common_awsim_labs_sensor_launch/package.xml
+++ b/common_awsim_labs_sensor_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>common_awsim_labs_sensor_launch</name>
-  <version>0.1.0</version>
+  <version>0.39.0</version>
   <description>The common_sensor_launch package</description>
   <maintainer email="piotr.jaroszek@robotec.ai">Piotr Jaroszek</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
## Description

This makes the release for 0.39.0 which is compatible with autoware.universe 0.39.0

## Related Issue
https://github.com/autowarefoundation/autoware/issues/5544

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
