### PR TITLE
ci(sync-files): use the template repo

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -7,6 +7,8 @@
     - source: .github/dependabot.yaml
     - source: .github/pull_request_template.md
     - source: .github/stale.yml
+    - source: .github/workflows/build-and-test.yaml
+    - source: .github/workflows/build-and-test-differential.yaml
     - source: .github/workflows/cancel-previous-workflows.yaml
     - source: .github/workflows/check-build-depends.yaml
     - source: .github/workflows/clang-tidy-pr-comments.yaml
@@ -30,8 +32,3 @@
     - source: CONTRIBUTING.md
     - source: DISCLAIMER.md
     - source: LICENSE
-
-- repository: autowarefoundation/autoware_common
-  files:
-    - source: .github/workflows/build-and-test.yaml
-    - source: .github/workflows/build-and-test-differential.yaml


### PR DESCRIPTION
## Description

It seems we forgot these 2 items in the previous PR:
- https://github.com/autowarefoundation/awsim_labs_sensor_kit_launch/pull/13

Parent issue:
- https://github.com/autowarefoundation/autoware/issues/4058

## How was this PR tested?

- https://github.com/autowarefoundation/awsim_labs_sensor_kit_launch/pull/16

## Notes for reviewers

None.

## Effects on system behavior

None.
