### PR TITLE
chore: remove unnecessary dependency to velodyne_monitor

### DIFF
--- a/common_awsim_labs_sensor_launch/package.xml
+++ b/common_awsim_labs_sensor_launch/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <exec_depend>velodyne_driver</exec_depend>
-  <exec_depend>velodyne_monitor</exec_depend>
   <exec_depend>velodyne_pointcloud</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
## Description

The velodyne_monitor package is not used anywhere in the launch file. Therefore, I'm removing it from package.xml

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
