### PR TITLE
refactor(awsim_labs_sensor_kit_launch): removed tamagawa_imu_driver

### DIFF
--- a/awsim_labs_sensor_kit_launch/package.xml
+++ b/awsim_labs_sensor_kit_launch/package.xml
@@ -13,7 +13,6 @@
   <exec_depend>autoware_pointcloud_preprocessor</exec_depend>
   <exec_depend>autoware_vehicle_velocity_converter</exec_depend>
   <exec_depend>common_sensor_launch</exec_depend>
-  <exec_depend>tamagawa_imu_driver</exec_depend>
   <exec_depend>topic_tools</exec_depend>
   <exec_depend>ublox_gps</exec_depend>
   <exec_depend>usb_cam</exec_depend>


### PR DESCRIPTION
## Description

Removed `tamagawa_imu_driver` as a dependency.

See https://github.com/autowarefoundation/autoware/issues/3366

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
